### PR TITLE
Improve perkakas log

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -50,27 +50,6 @@ const (
 	TraceLevel
 )
 
-func (l Level) String() string {
-	switch l {
-	case PanicLevel:
-		return "Panic"
-	case FatalLevel:
-		return "Fatal"
-	case ErrorLevel:
-		return "error"
-	case WarnLevel:
-		return "warning"
-	case InfoLevel:
-		return "info"
-	case DebugLevel:
-		return "debug"
-	case TraceLevel:
-		return "trace"
-	default:
-		return "unknown"
-	}
-}
-
 func (level Level) MarshalText() ([]byte, error) {
 	switch level {
 	case TraceLevel:

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -88,6 +88,18 @@ func (suite *LogTestSuite) TestMessageStackType() {
 	assert.Panics(suite.T(), func() { ensureStackType(message) }, "should panic")
 }
 
+func (suite *LogTestSuite) TestFindMaxLevel() {
+	msgs := []message{
+		message{Level: TraceLevel},
+		message{Level: DebugLevel},
+		message{Level: WarnLevel},
+		message{Level: ErrorLevel},
+	}
+	
+	maxLevel := suite.Logger.findMaxLevel(msgs)
+	assert.Equal(suite.T(), ErrorLevel, maxLevel)
+}
+
 func TestLogTestSuite(t *testing.T) {
 	suite.Run(t, new(LogTestSuite))
 }


### PR DESCRIPTION
## What does this PR do? 
[Link to issue](https://kitabisa.atlassian.net/browse/ARJ-19)

Additional notes for the card:
Since perkakas log is collected before print, so it requires check for
the max level of the collected error message, and prints the error
message to the stdout/stderr regarding the max level found.

## Why are we doing this? Any context or related work?
We want to manage/organize error log output

## Where should a reviewer start?
Take attention to code changes related to logic that separating log
output (stderr/stdout) and function that decide the max level.

## Manual testing steps?
No manual testing steps.

## Screenshots
No screenshot needed.

## Database changes
No database changed.

## Config changes
No config changed.

## Deployment instructions
Usual delpoyment.
