### PR TITLE
Move kitabisa header function to perkakas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gojektech/heimdall v5.0.2+incompatible
 	github.com/gojektech/valkyrie v0.0.0-20190210220504-8f62c1e7ba45 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
 	github.com/im7mortal/kmutex v1.0.0
 	github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/random/random.go
+++ b/random/random.go
@@ -1,0 +1,14 @@
+package random
+
+import (
+	"github.com/google/uuid"
+)
+
+func UUID() (id string, err error) {
+	newId, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	return newId.String(), nil
+}


### PR DESCRIPTION
## What does this PR do?
Move kitabisa generate header from tuman to perkakas

## Why are we doing this? Any context or related work?
In order to move the service client code from tuman
to client-service repo, we need to separate common functions
so client service library doesn't has dependency to tuman.
It's not supposed to be like that anyway.

## Where should a reviewer start?
--

## Manual testing steps?
--

## Screenshots
No screenshot needed.

## Config changes
No config changed.

## Database changes
No database changed.

## Deployment instructions
Usual deployment.