### PR TITLE
Support custom support id on generate kitabisa header

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -48,23 +48,26 @@ func ExcludeSensitiveRequestBody(body *string) {
 	*body = result
 }
 
-func KitabisaHeader(req *http.Request, clientName, clientVersion string) *http.Request {
+func KitabisaHeader(req *http.Request, clientName, clientVersion, requestID string) *http.Request {
 	timestamp := fmt.Sprintf("%d", time.Now().Unix())
 
 	if !govalidator.IsSemver(clientVersion) {
 		clientVersion = "1.0.0"
 	}
 
-	id, err := random.UUID()
-	if err != nil {
-		id = fmt.Sprintf("%s-%s-error-generate-uuid", clientName, clientVersion)
+	if requestID == "" {
+		var err error
+		requestID, err = random.UUID()
+		if err != nil {
+			requestID = fmt.Sprintf("%s-%s-error-generate-uuid", clientName, clientVersion)
+		}
 	}
 
 	if req.Header == nil {
 		req.Header = make(http.Header)
 	}
 
-	req.Header.Set("X-Ktbs-Request-ID", id)
+	req.Header.Set("X-Ktbs-Request-ID", requestID)
 	req.Header.Set("X-Ktbs-Client-Name", clientName)
 	req.Header.Set("X-Ktbs-Client-Version", clientVersion)
 	req.Header.Set("X-Ktbs-Time", timestamp)


### PR DESCRIPTION
## What does this PR do?
If request ID empty when generate kitabisa header,
it will be generated automatically

## Why are we doing this? Any context or related work?
To provide functionality if client want to use custom
request id on the header.

## Where should a reviewer start?
--

## Manual testing steps?
--

## Screenshots
No screenshot needed.

## Config changes
No config changed.

## Database changes
No database changed.

## Deployment instructions
Usual deployment.