### PR TITLE
Adding helper status code

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -73,3 +73,19 @@ func KitabisaHeader(req *http.Request, clientName, clientVersion, requestID stri
 	req.Header.Set("X-Ktbs-Time", timestamp)
 	return req
 }
+
+func IsSuccess(code int) bool {
+	return code >= 200 && code <= 299
+}
+
+func IsClientError(code int) bool {
+	return code >= 400 && code <= 499
+}
+
+func IsRedirection(code int) bool {
+	return code >= 300 && code <= 399
+}
+
+func IsServerError(code int) bool {
+	return code >= 500 && code <= 599
+}

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -2,6 +2,7 @@ package httputil
 
 import (
 	"github.com/stretchr/testify/assert"
+	"net/http"
 	"testing"
 )
 
@@ -15,4 +16,36 @@ func TestExcludeSensitiveRequestBody(t *testing.T) {
 
 	match = passRemover.MatchString(sourceText)
 	assert.False(t, match)
+}
+
+func TestIsSuccess(t *testing.T) {
+	code := http.StatusOK
+	assert.True(t, IsSuccess(code))
+
+	failCode := http.StatusBadGateway
+	assert.False(t, IsSuccess(failCode))
+}
+
+func TestIsRedirection(t *testing.T) {
+	code := http.StatusMovedPermanently
+	assert.True(t, IsRedirection(code))
+
+	failCode := http.StatusBadGateway
+	assert.False(t, IsRedirection(failCode))
+}
+
+func TestIsClientError(t *testing.T) {
+	code := http.StatusNotAcceptable
+	assert.True(t, IsClientError(code))
+
+	failCode := http.StatusBadGateway
+	assert.False(t, IsRedirection(failCode))
+}
+
+func TestIsServerError(t *testing.T) {
+	code := http.StatusBadGateway
+	assert.True(t, IsServerError(code))
+
+	failCode := http.StatusOK
+	assert.False(t, IsServerError(failCode))
 }


### PR DESCRIPTION
## What does this PR do?
Adding helper status code (IsSuccess, IsRedirection, etc) to ease HTTP status code checking

## Why are we doing this? Any context or related work?
Lately proposed in https://github.com/golang/go/issues/29652, and we need to implement this on HTTP response validator

## Where should a reviewer start?
httputil.go

## Screenshots
-
## Manual testing steps?
go test ./...
## Database changes
-
## Config changes
-
## Deployment instructions
-