### PR TITLE
Change error handling on ensureStackType function

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -239,7 +239,7 @@ func (l *Logger) addMessageStack(msg ...message) {
 func ensureStackType(stack interface{}) (val []message) {
 	val, ok := stack.([]message)
 	if !ok {
-		panic("perkakas/log: stack trace is expecting a message but found other types")
+		return []message{}
 	}
 
 	return


### PR DESCRIPTION
## What does this PR do?
Change error handling so when slice of message is nil, instead of rising panic,
it will return empty slice.

## Why are we doing this? Any context or related work?
Eliminate false alarm in log. Because nothing wrong in logic but when type checking
not satisfied it raising panic that make people think that there are serious problem.

## Where should a reviewer start?
--

## Screenshots
--

## Manual testing steps?
--

## Database changes
No database changed.

## Config changes
No config changed.

## Deployment instructions
Usual deployment.