### PR TITLE
adding creating zerolog sublog utils

### DIFF
--- a/internal/ctx.go
+++ b/internal/ctx.go
@@ -1,0 +1,12 @@
+package internal
+
+type contextKey string
+
+var (
+	// CtxXKtbsRequestID context key for X-Ktbs-Request-ID
+	CtxXKtbsRequestID contextKey = "X-Ktbs-Request-ID"
+)
+
+func (c contextKey) String() string {
+	return string(c)
+}

--- a/log/sublog.go
+++ b/log/sublog.go
@@ -1,0 +1,26 @@
+package log
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+type contextKey string
+
+var (
+	CtxXKtbsRequestID contextKey = "X-Ktbs-Request-ID"
+)
+
+func (c contextKey) String() string {
+	return string(c)
+}
+
+// GetSublogger get zerolog sublogger
+func GetSublogger(ctx context.Context, ctxName string) zerolog.Logger {
+	return log.With().
+		Str(CtxXKtbsRequestID.String(), ctx.Value(CtxXKtbsRequestID).(string)).
+		Str("label", ctxName).
+		Logger()
+}

--- a/log/sublog.go
+++ b/log/sublog.go
@@ -3,24 +3,16 @@ package log
 import (
 	"context"
 
+	"github.com/kitabisa/perkakas/v2/internal"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
-type contextKey string
-
-var (
-	CtxXKtbsRequestID contextKey = "X-Ktbs-Request-ID"
-)
-
-func (c contextKey) String() string {
-	return string(c)
-}
-
 // GetSublogger get zerolog sublogger
+// WIP: middleware for set X-Ktbs-Request-ID to context
 func GetSublogger(ctx context.Context, ctxName string) zerolog.Logger {
 	return log.With().
-		Str(CtxXKtbsRequestID.String(), ctx.Value(CtxXKtbsRequestID).(string)).
+		Str(internal.CtxXKtbsRequestID.String(), ctx.Value(internal.CtxXKtbsRequestID).(string)).
 		Str("label", ctxName).
 		Logger()
 }

--- a/log/sublog_test.go
+++ b/log/sublog_test.go
@@ -1,0 +1,30 @@
+package log
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/kitabisa/perkakas/v2/internal"
+)
+
+func TestSublogger(t *testing.T) {
+	ctx := context.WithValue(context.Background(), internal.CtxXKtbsRequestID, "111111")
+	f, err := os.Create("logfile-test.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	subLog := GetSublogger(ctx, "test-context-name-1")
+	subLog.Output(f)
+	subLog.Err(errors.New("test-error")).Msg("test-message")
+
+	subLog2 := GetSublogger(ctx, "test-context-name-2")
+	subLog2.Output(f)
+	subLog2.Info().Msg("test-message")
+
+	// as log is not printed when test is success, need to uncomment line below :D
+	// t.FailNow()
+}

--- a/log/sublog_test.go
+++ b/log/sublog_test.go
@@ -3,7 +3,6 @@ package log
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/kitabisa/perkakas/v2/internal"
@@ -11,18 +10,11 @@ import (
 
 func TestSublogger(t *testing.T) {
 	ctx := context.WithValue(context.Background(), internal.CtxXKtbsRequestID, "111111")
-	f, err := os.Create("logfile-test.log")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close()
 
 	subLog := GetSublogger(ctx, "test-context-name-1")
-	subLog.Output(f)
 	subLog.Err(errors.New("test-error")).Msg("test-message")
 
 	subLog2 := GetSublogger(ctx, "test-context-name-2")
-	subLog2.Output(f)
 	subLog2.Info().Msg("test-message")
 
 	// as log is not printed when test is success, need to uncomment line below :D


### PR DESCRIPTION
## What does this PR do?
as PR title

## Why are we doing this? Any context or related work?
this is one utils for easier and standardize logging if you using zerolog,
so that the log will always have X-Ktbs-Request-ID and your own label for easier to track.
Usually I get this sublogger on every start of the function, with label as the function name.
Zerolog itself actually have caller function.

## Example Logs
```
{"level":"info","X-Ktbs-Request-ID":"","label":"Handler.OTP.Send","time":1595565059,"caller":"/Users/ardit/Works/Kitabisa/steril/internal/app/handler/otp.go:94","message":"call prepare otp service"}
{"level":"info","X-Ktbs-Request-ID":"","label":"Handler.OTP.Send","time":1595565059,"caller":"/Users/ardit/Works/Kitabisa/steril/internal/app/handler/otp.go:100","message":"call send otp service"}
```

