### PR TITLE
moving internal to ctxkeys

### DIFF
--- a/log/sublog_test.go
+++ b/log/sublog_test.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kitabisa/perkakas/v2/internal"
+	"github.com/kitabisa/perkakas/v2/ctxkeys"
 )
 
 func TestSublogger(t *testing.T) {
-	ctx := context.WithValue(context.Background(), internal.CtxXKtbsRequestID, "111111")
+	ctx := context.WithValue(context.Background(), ctxkeys.CtxXKtbsRequestID, "111111")
 
 	subLog := GetSublogger(ctx, "test-context-name-1")
 	subLog.Err(errors.New("test-error")).Msg("test-message")

--- a/middleware/std_header_check.go
+++ b/middleware/std_header_check.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/kitabisa/perkakas/v2/ctxkeys"
 	phttp "github.com/kitabisa/perkakas/v2/http"
-	"github.com/kitabisa/perkakas/v2/internal"
 	"github.com/kitabisa/perkakas/v2/signature"
 	"github.com/kitabisa/perkakas/v2/structs"
 )
@@ -79,7 +79,7 @@ func NewHeaderCheck(hctx phttp.HttpHandlerContext, secretKey string) func(next h
 func RequestIDToContextMiddleware(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		r = r.WithContext(context.WithValue(ctx, internal.CtxXKtbsRequestID, r.Header.Get(internal.CtxXKtbsRequestID.String())))
+		r = r.WithContext(context.WithValue(ctx, ctxkeys.CtxXKtbsRequestID, r.Header.Get(ctxkeys.CtxXKtbsRequestID.String())))
 		next.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)


### PR DESCRIPTION
## What does this PR do?
moving internal package to ctxkeys

## Why are we doing this? Any context or related work?
need to use what's on internal

nb:
- sorry I make a push directly to master before on this commit https://github.com/kitabisa/perkakas/commit/2a5622fb3f1c81bd0e3f6c33193dace22d4d27cf