### PR TITLE
removing XKtbsTime validation

### DIFF
--- a/middleware/std_header_check.go
+++ b/middleware/std_header_check.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
-	"time"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/kitabisa/perkakas/v2/ctxkeys"
@@ -48,18 +46,6 @@ func NewHeaderCheck(hctx phttp.HttpHandlerContext, secretKey string) func(next h
 			_, err := govalidator.ValidateStruct(header)
 			if err != nil {
 				writer.WriteError(w, structs.ErrInvalidHeader)
-				return
-			}
-
-			theTime, err := strconv.ParseInt(header.XKtbsTime, 10, 64)
-			if err != nil {
-				writer.WriteError(w, structs.ErrInvalidHeader)
-				return
-			}
-
-			// delay request should not be more than 1 min
-			if theTime+60 < time.Now().UTC().Unix() {
-				writer.WriteError(w, structs.ErrInvalidHeaderTime)
 				return
 			}
 


### PR DESCRIPTION
## What does this PR do?
removing validation on X-Ktbs-Time

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/ARJ-271


## Deployment instructions
as usual
