### PR TITLE
create custom chi logger-like for only 4xx and 5xx http status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/checkr/goflagr v0.0.0-20191204001954-97a36973fd24
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/elazarl/goproxy v0.0.0-20200809112317-0581fc3aee2d // indirect
+	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/gojektech/heimdall v5.0.2+incompatible
 	github.com/gojektech/valkyrie v0.0.0-20190210220504-8f62c1e7ba45 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
+github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -33,6 +33,7 @@ func main() {
     // use the middleware
     router.Use(midd)
     router.Use(logMiddleware)
+    router.Use(CustomChiLogger) // will print go-chi-like request log only for 4xx and 5xx HTTP status code
     
 	router.Get("/", helloHandler.ServeHTTP)
 

--- a/middleware/custom_chi_logger.go
+++ b/middleware/custom_chi_logger.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	cmiddleware "github.com/go-chi/chi/middleware"
+)
+
+var customChiLogger = customRequestLogger(&cmiddleware.DefaultLogFormatter{Logger: log.New(os.Stdout, "", log.LstdFlags), NoColor: false})
+
+// CustomChiLogger create custom chi logger-like that print request log only for 4xx and 5xx error
+func CustomChiLogger(next http.Handler) http.Handler {
+	return customChiLogger(next)
+}
+
+func customRequestLogger(f cmiddleware.LogFormatter) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			entry := f.NewLogEntry(r)
+			ww := cmiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			t1 := time.Now()
+
+			next.ServeHTTP(ww, cmiddleware.WithLogEntry(r, entry))
+
+			if ww.Status() >= http.StatusBadRequest {
+				entry.Write(ww.Status(), ww.BytesWritten(), ww.Header(), time.Since(t1), nil)
+			}
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/middleware/custom_chi_logger.go
+++ b/middleware/custom_chi_logger.go
@@ -11,7 +11,7 @@ import (
 
 var customChiLogger = customRequestLogger(&cmiddleware.DefaultLogFormatter{Logger: log.New(os.Stdout, "", log.LstdFlags), NoColor: false})
 
-// CustomChiLogger create custom chi logger-like that print request log only for 4xx and 5xx error
+// CustomChiLogger create custom chi logger-like that print request log only for 4xx and 5xx HTTP status code
 func CustomChiLogger(next http.Handler) http.Handler {
 	return customChiLogger(next)
 }


### PR DESCRIPTION
## What does this PR do?
create custom chi logger-like for only 4xx and 5xx http status

## Usage
```go
router.Use(CustomChiLogger) 
```

## Requirement
- Your project must update go-chi to v4.1.2