### PR TITLE
ARJ-292 update sse client to support kafka cluster host

### DIFF
--- a/sse/README.md
+++ b/sse/README.md
@@ -21,7 +21,8 @@ func main() {
 
     // By default, SSE client will set the kafka version to 2.5.0. You can change the kafka version using
     // `SetKafkaVersion()` and see the kafka version currently applied with `GetKafkaVersion()`
-    client := sse.NewSseClient("localhost:9092", kafka.WithClientID("katresnan"), kafka.WithRetryMax(5))
+    kafkaHost := []string{"localhost:9092"}
+    client := sse.NewSseClient(kafkaHost, kafka.WithClientID("katresnan"), kafka.WithRetryMax(5))
 
     err := client.PublishEvent(context.Background(), "topic", "key", data)
     if err != nil {

--- a/sse/sse_test.go
+++ b/sse/sse_test.go
@@ -2,19 +2,22 @@ package sse
 
 import (
 	"context"
+	"testing"
+
 	"github.com/Shopify/sarama"
 	"github.com/kitabisa/perkakas/v2/queue/kafka"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestNewSseClient(t *testing.T) {
-	client := NewSseClient("localhost:9092", kafka.WithClientID("unit-test"))
+	kafkaHost := []string{"localhost:9092"}
+	client := NewSseClient(kafkaHost, kafka.WithClientID("unit-test"))
 	assert.NotNil(t, client)
 }
 
 func TestClient_GetSetKafkaVersion(t *testing.T) {
-	client := NewSseClient("localhost:9092", kafka.WithClientID("unit-test"))
+	kafkaHost := []string{"localhost:9092"}
+	client := NewSseClient(kafkaHost, kafka.WithClientID("unit-test"))
 	client.SetKafkaVersion(context.Background(), "2.5.0")
 	version := client.GetKafkaVersion(context.Background())
 	assert.Equal(t, "2.5.0", version)
@@ -28,8 +31,9 @@ func TestClient_PublishEvent(t *testing.T) {
 		"ProduceRequest": sarama.NewMockProduceResponse(t),
 	})
 
-	client := NewSseClient(mockBroker.Addr(), kafka.WithClientID("katresnan"), kafka.WithRetryMax(5))
-	data := map[string]interface{} {
+	kafkaHost := []string{mockBroker.Addr()}
+	client := NewSseClient(kafkaHost, kafka.WithClientID("katresnan"), kafka.WithRetryMax(5))
+	data := map[string]interface{}{
 		"name": "test",
 	}
 


### PR DESCRIPTION
## What does this PR do?
- update sse client to support kafka cluster host

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/ARJ-292
