### PR TITLE
fixing wrong usage context

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -3,7 +3,7 @@ package http
 import (
 	"net/http"
 
-	"github.com/rs/zerolog/log"
+	zlog "github.com/kitabisa/perkakas/v2/log"
 )
 
 type HttpHandler struct {
@@ -22,7 +22,7 @@ func (h HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	data, pageToken, err := h.H(w, r)
 
 	if err != nil {
-		log.Err(err).Msgf("Response: %+v", data)
+		zlog.Zlogger(r.Context()).Err(err).Msgf("Response: %+v", data)
 		h.WriteError(w, err)
 		return
 	}

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -11,14 +11,13 @@ import (
 // RequestIDToContextAndLogMiddleware set X-Ktbs-Request-ID header value and logger to context
 func RequestIDToContextAndLogMiddleware(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
 		reqID := r.Header.Get(ctxkeys.CtxXKtbsRequestID.String())
-		r = r.WithContext(context.WithValue(ctx, ctxkeys.CtxXKtbsRequestID, reqID))
+		r = r.WithContext(context.WithValue(r.Context(), ctxkeys.CtxXKtbsRequestID, reqID))
 
 		logger := log.With().
 			Str(ctxkeys.CtxXKtbsRequestID.String(), reqID).
 			Logger()
-		r = r.WithContext(context.WithValue(ctx, ctxkeys.CtxLogger, logger))
+		r = r.WithContext(context.WithValue(r.Context(), ctxkeys.CtxLogger, logger))
 
 		next.ServeHTTP(w, r)
 	}


### PR DESCRIPTION
## What does this PR do?
bugfix, wrong context usage on the middleware

## Why are we doing this? Any context or related work?
the X-Ktbs-Request-ID is not set on the request context as supposed to be

