### PR TITLE
fixing panic error on empty logger

### DIFF
--- a/log/zlogger.go
+++ b/log/zlogger.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/kitabisa/perkakas/v2/ctxkeys"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 // Zlogger get zerolog sublogger from context
 func Zlogger(ctx context.Context) *zerolog.Logger {
-	var logger *zerolog.Logger
+	logger := &log.Logger
 	if ctx.Value(ctxkeys.CtxLogger) != nil {
 		l := ctx.Value(ctxkeys.CtxLogger).(zerolog.Logger)
 		logger = &l

--- a/log/zlogger_test.go
+++ b/log/zlogger_test.go
@@ -3,10 +3,13 @@ package log
 import (
 	"bytes"
 	"context"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/kitabisa/perkakas/v2/ctxkeys"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,4 +20,33 @@ func TestZlogger(t *testing.T) {
 	Zlogger(ctx).Log().Send()
 	assert.Contains(t, out.String(), "X-Ktbs-Request-ID")
 	assert.Contains(t, out.String(), "any-request-id")
+}
+
+func TestZloggerEmpty(t *testing.T) {
+	ctx := context.Background()
+	file, err := os.Create("log.txt")
+	if err != nil {
+		t.FailNow()
+	}
+	defer os.Remove("log.txt")
+	log.Logger = zerolog.New(file).With().Caller().Timestamp().Logger()
+
+	Zlogger(ctx).Log().Msg("anylog")
+	file.Close()
+	out, err := ioutil.ReadFile("log.txt")
+	if err != nil {
+		t.FailNow()
+	}
+
+	assert.Contains(t, string(out), "anylog")
+}
+
+func TestZloggerWithoutInitiate(t *testing.T) {
+	ctx := context.Background()
+
+	Zlogger(ctx).Log().Msg("anylog")
+
+	// as long as there's no panic error, it's okay.
+	// Code below only make sure that the log printed on os.stdout
+	// assert.Equal(t, "ole", "ale")
 }


### PR DESCRIPTION
## What does this PR do?
Fixing panic error caused by nil pointer, when context is not having the logger object
Adding unit test for it


