### PR TITLE
add mapstructure support to response struct

### DIFF
--- a/structs/http_response.go
+++ b/structs/http_response.go
@@ -2,21 +2,21 @@ package structs
 
 // Meta defines meta format format for api format
 type Meta struct {
-	Version string `json:"version"`
-	Status  string `json:"api_status"`
-	APIEnv  string `json:"api_env"`
+	Version string `json:"version" mapstructure:"version"`
+	Status  string `json:"api_status" mapstructure:"api_status"`
+	APIEnv  string `json:"api_env" mapstructure:"api_env"`
 }
 
 type Response struct {
-	ResponseCode string       `json:"response_code"`
-	ResponseDesc ResponseDesc `json:"response_desc"`
-	Meta         Meta         `json:"meta"`
+	ResponseCode string       `json:"response_code" mapstructure:"response_code"`
+	ResponseDesc ResponseDesc `json:"response_desc" mapstructure:"response_desc"`
+	Meta         Meta         `json:"meta" mapstructure:"meta"`
 }
 
 type SuccessResponse struct {
 	Response
-	Next *string     `json:"next,omitempty"`
-	Data interface{} `json:"data,omitempty"`
+	Next *string     `json:"next,omitempty" mapstructure:"next,omitempty"`
+	Data interface{} `json:"data,omitempty" mapstructure:"data,omitempty"`
 }
 
 // error Response
@@ -31,6 +31,6 @@ func (e *ErrorResponse) Error() string {
 
 // ResponseDesc defines details data response
 type ResponseDesc struct {
-	ID string `json:"id"`
-	EN string `json:"en"`
+	ID string `json:"id" mapstructure:"id"`
+	EN string `json:"en" mapstructure:"en"`
 }


### PR DESCRIPTION
## What does this PR do?
- Add mapstructure support in perkakas response. Perkakas error struct will be used & decoded in async donation and will be sent to SSE.

## Why are we doing this? Any context or related work?
https://kitabisa.atlassian.net/browse/ARJ-310
