### PR TITLE
Improve http metrics

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -36,8 +36,14 @@ func NewHttpHandler(c HttpHandlerContext, opts ...HandlerOption) func(handler fu
 }
 
 // WithMetric wire statsd client to perkakas handler
-func WithMetric(m *statsd.Client, svcName string) HandlerOption {
+func WithMetric(telegrafHost string, telegrafPort int, svcName string) HandlerOption {
 	return func(h *HttpHandler) {
+		host := fmt.Sprintf("%s:%d", telegrafHost, telegrafPort)
+		m, err := statsd.New(host)
+		if err != nil {
+			panic(err)
+		}
+
 		h.Metric = m
 		h.ServiceName = svcName
 	}

--- a/http/handler.go
+++ b/http/handler.go
@@ -86,7 +86,7 @@ func (h HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// response time
 		responseTimeTag := []string{fmt.Sprintf("service_name:%s", h.ServiceName), fmt.Sprintf("endpoint:%s", URL), fmt.Sprintf("request_id:%s", r.Header.Get("X-Ktbs-Request-ID"))}
 
-		h.Metric.Incr("RESPONSE_TIME", responseTimeTag, float64(diff.Milliseconds()))
+		h.Metric.Count("RESPONSE_TIME", diff.Milliseconds(), responseTimeTag, 1)
 	}
 
 	h.Write(w, data, pageToken)

--- a/http/handler.go
+++ b/http/handler.go
@@ -78,7 +78,15 @@ func (h HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				status = "SERVER_ERROR"
 			}
 
-			tag = append(tag, fmt.Sprintf("service_name:%s", h.ServiceName), fmt.Sprintf("endpoint:%s", URL), fmt.Sprintf("http_status:%d", statusCode), fmt.Sprintf("response_code:%s", responseCode), fmt.Sprintf("request_id:%s", r.Header.Get("X-Ktbs-Request-ID")), fmt.Sprintf("status:%s", status), fmt.Sprintf("method:%s", r.Method))
+			tag = append(tag,
+				fmt.Sprintf("service_name:%s", h.ServiceName),
+				fmt.Sprintf("method:%s", r.Method),
+				fmt.Sprintf("endpoint:%s", URL),
+				fmt.Sprintf("http_status:%d", statusCode),
+				fmt.Sprintf("response_code:%s", responseCode),
+				fmt.Sprintf("request_id:%s", r.Header.Get("X-Ktbs-Request-ID")),
+				fmt.Sprintf("status:%s", status),
+			)
 
 			h.Metric.Incr(table, tag, 1)
 		}
@@ -95,7 +103,12 @@ func (h HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.Metric.Incr("SUCCESS", tag, 1)
 
 		// response time
-		responseTimeTag := []string{fmt.Sprintf("service_name:%s", h.ServiceName), fmt.Sprintf("endpoint:%s", URL), fmt.Sprintf("request_id:%s", r.Header.Get("X-Ktbs-Request-ID"))}
+		responseTimeTag := []string{
+			fmt.Sprintf("service_name:%s", h.ServiceName),
+			fmt.Sprintf("method:%s", r.Method),
+			fmt.Sprintf("endpoint:%s", URL),
+			fmt.Sprintf("request_id:%s", r.Header.Get("X-Ktbs-Request-ID")),
+		}
 
 		h.Metric.Count("RESPONSE_TIME", diff.Milliseconds(), responseTimeTag, 1)
 	}


### PR DESCRIPTION
## What does this PR do?
- blacklist health check endpoint for http metrics
- update response_time metrics from increment to counter
- initiate statsd client in perkakas (for http metrics) instead of passing statsd client from external. (prevent using namespace for http metrics statsd. Contoh case di komen PR ini https://github.com/kitabisa/tuman-v2/pull/32) 