### PR TITLE
HMAC Signature constant time checks

### DIFF
--- a/signature/hmac_signature.go
+++ b/signature/hmac_signature.go
@@ -21,7 +21,10 @@ func IsMatchHmac(data, signature, secretKey string) bool {
 	h.Write([]byte(data))
 
 	expected := h.Sum(nil)
-	sign, _ := hex.DecodeString(signature)
+	sign, err := hex.DecodeString(signature)
+	if err != nil {
+		return false
+	}
 
 	if hmac.Equal(expected, sign) {
 		return true

--- a/signature/hmac_signature.go
+++ b/signature/hmac_signature.go
@@ -20,10 +20,10 @@ func IsMatchHmac(data, signature, secretKey string) bool {
 	h := hmac.New(sha256.New, []byte(secretKey))
 	h.Write([]byte(data))
 
-	result := h.Sum(nil)
-	expected := hex.EncodeToString(result)
+	expected := h.Sum(nil)
+	sign, _ := hex.DecodeString(signature)
 
-	if signature == expected {
+	if hmac.Equal(expected, sign) {
 		return true
 	}
 	return false


### PR DESCRIPTION
## What does this PR do?
Avoid time attack by using `hmac.Equal`

## Manual testing steps?
```
go test ./signature
```