### PR TITLE
Added new thread safe add error for concurrent read write map

### DIFF
--- a/http/writer.go
+++ b/http/writer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"reflect"
+	"sync"
 
 	"github.com/kitabisa/perkakas/v2/structs"
 )
@@ -29,7 +30,14 @@ func NewContextHandler(meta structs.Meta) HttpHandlerContext {
 	}
 }
 
+var (
+	allData = make(map[string]string)
+	rwm     sync.RWMutex
+)
+
 func (hctx HttpHandlerContext) AddError(key error, value *structs.ErrorResponse) {
+	rwm.Lock()
+	defer rwm.Unlock()
 	hctx.E[key] = value
 }
 


### PR DESCRIPTION
## What does this PR do?
If we use add error during concurrency, sometimes we will receive concurrent read map write

## Why are we doing this? Any context or related work?
found it during https://kitabisa.atlassian.net/browse/PPS-337
You can try create a go routine call that call normal AddError. Keep trying to call it and then it will throw error.

I don't want to add the RWMutex to existing AddError because AddError is being used by other repository and it's not necessary to use thread safe if concurrency is not related. In my case, concurrent topup creation must be handled

## Where should a reviewer start?
writers.go

## Screenshots
Before (using normal AddError)
![image](https://user-images.githubusercontent.com/11158339/116178065-20342a80-a73f-11eb-8e24-c9e2072f54c6.png)
![Screen Shot 2021-04-27 at 10 15 46](https://user-images.githubusercontent.com/11158339/116179460-99348180-a741-11eb-8800-27652ca31327.png)

After 
consistent result with concurrent request being handled and 1 request made it through
![Screen Shot 2021-04-27 at 10 03 35](https://user-images.githubusercontent.com/11158339/116179474-9e91cc00-a741-11eb-823c-10df2457f5a9.png)
![Screen Shot 2021-04-27 at 10 15 56](https://user-images.githubusercontent.com/11158339/116179486-a5204380-a741-11eb-8c77-8e4d2ab6f978.png)


## Manual testing steps?
please ask @sswastioyono18 



## Database changes
_optional -- If there's database changes, put it here_

## Config changes
_optional -- If there's config changes, put it here_

## Deployment instructions
_optional -- Better to put it if there's some 'special case' for deployment_
