### PR TITLE
added string call to request id

### DIFF
--- a/log/sublog.go
+++ b/log/sublog.go
@@ -12,8 +12,8 @@ import (
 // TODO: TO BE DEPRECATED after v2.14.6
 func GetSublogger(ctx context.Context, ctxName string) zerolog.Logger {
 	reqID := ""
-	if ctx.Value(ctxkeys.CtxXKtbsRequestID) != nil {
-		reqID = ctx.Value(ctxkeys.CtxXKtbsRequestID).(string)
+	if ctx.Value(ctxkeys.CtxXKtbsRequestID.String()) != nil {
+		reqID = ctx.Value(ctxkeys.CtxXKtbsRequestID.String()).(string)
 	}
 
 	return log.With().

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -12,7 +12,7 @@ import (
 func RequestIDToContextAndLogMiddleware(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		reqID := r.Header.Get(ctxkeys.CtxXKtbsRequestID.String())
-		r = r.WithContext(context.WithValue(r.Context(), ctxkeys.CtxXKtbsRequestID, reqID))
+		r = r.WithContext(context.WithValue(r.Context(), ctxkeys.CtxXKtbsRequestID.String(), reqID))
 
 		logger := log.With().
 			Str(ctxkeys.CtxXKtbsRequestID.String(), reqID).


### PR DESCRIPTION
## What does this PR do?
Since we use ctx keys "X-Ktbs-Request-Id" everywhere, we should stick to one pattern on "how to set" and "how to access". 

Currently, many places use 
```
ctxkeys.CtxXKtbsRequestID
```

but a lot of places do these as well

```
ctxkeys.CtxXKtbsRequestID.String()
```

I think it's better to use `String()` because the ctxkeys type is string
We just have to be careful to always remember to set the `String()` during set and get

## Why are we doing this? Any context or related work?
because I want to implement distributed tracing and this change will allow me to carry request id to wong

## Where should a reviewer start?
_optional -- if your changes affected so much files, it is encouraged to give helper for reviewer_

## Screenshots
_optional -- You may put the database, sequence or any diagram needed_

## Manual testing steps?
_Steps to do tests. including all possible that can hape_

## Database changes
_optional -- If there's database changes, put it here_

## Config changes
_optional -- If there's config changes, put it here_

## Deployment instructions
_optional -- Better to put it if there's some 'special case' for deployment_
